### PR TITLE
Mount visualization canvas in background portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link href="/src/styles.css" rel="stylesheet" />
   </head>
   <body>
+    <div id="bg-viz-portal" aria-hidden="true"></div>
     <div id="root"></div>
     <div id="preboot" class="preboot">Cargando…</div>
     <noscript class="noscript">Esta app necesita JavaScript.</noscript>

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,12 +12,6 @@ body{font-family:'Montserrat',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,
 .imgBox{ width:100%; aspect-ratio:16/9; background:rgba(0,0,0,.18); border:1px solid #374151; border-radius:10px; overflow:hidden; display:grid; place-items:center; }
 .img { width:100%; height:100%; object-fit: contain; display:block; }
 
-/* Viz al FONDO (detrás del contenido) */
-.bgViz{ position:fixed; inset:0; z-index:0; pointer-events:none; opacity:.76; }
-.bgViz canvas{ width:100%; height:100%; display:block; filter:blur(22px) saturate(120%); }
-
-/* Failsafe: si no puede ir detrás, esta clase lo sube al frente */
-.bgViz.front{ z-index:50; }
-
-/* Asegura que el contenido quede arriba del fondo */
-.container{ position:relative; z-index:1; }
+/* Portal de fondo para el visualizador */
+#bg-viz-portal{ position:fixed; inset:0; z-index:-1; pointer-events:none; }
+#bg-viz-portal canvas{ width:100%; height:100%; display:block; filter:blur(18px) saturate(120%); opacity:.82; }


### PR DESCRIPTION
## Summary
- Mount and style a dedicated `#bg-viz-portal` outside the React tree so the visualizer always sits behind the UI.
- Refactor `ColorSynth` to create/remove the portal canvas on mount, drive visualization rendering, and emit orbs via new helpers.
- Remove old in-tree canvas and related styles; add new background portal CSS.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b33c352f5c83258360c4e52171379a