### PR TITLE
Handle null Tone context before configuring lookAhead

### DIFF
--- a/src/synth/ColorSynth.jsx
+++ b/src/synth/ColorSynth.jsx
@@ -341,7 +341,13 @@ useEffect(()=>{
   },[])
 
   useEffect(()=>{
-    try { const ctx = Tone.getContext(); ctx.lookAhead = PERF.LOOK_AHEAD; ctx.latencyHint = 'playback' } catch{}
+    try {
+      const ctx = Tone.getContext()
+      if (ctx) {
+        ctx.lookAhead = PERF.LOOK_AHEAD
+        ctx.latencyHint = 'playback'
+      }
+    } catch{}
     return ()=>{ hardStop() }
   }, [])
 


### PR DESCRIPTION
## Summary
- Guard Tone.js context initialization to avoid null lookAhead access

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf30d30c308325a9ebfacef294cc5f