### PR TITLE
refactor: use named hooks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Synth from './synth/ColorSynth.jsx'
 
 export default function App(){

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import { StrictMode, useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './styles.css'
 
 function ErrorBoundary({ children }) {
-  const [err, setErr] = React.useState(null)
-  React.useEffect(() => {
+  const [err, setErr] = useState(null)
+  useEffect(() => {
     const onErr = (ev) => setErr(ev?.error || ev)
     const onRej = (ev) => setErr(ev?.reason || ev)
     window.addEventListener('error', onErr)
@@ -19,5 +19,5 @@ function ErrorBoundary({ children }) {
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'))
-root.render(<React.StrictMode><ErrorBoundary><App/></ErrorBoundary></React.StrictMode>)
+root.render(<StrictMode><ErrorBoundary><App/></ErrorBoundary></StrictMode>)
 if (window.__hidePreboot) window.__hidePreboot()

--- a/src/synth/ColorSynth.jsx
+++ b/src/synth/ColorSynth.jsx
@@ -1,12 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import * as Tone from 'tone'
 import { Upload, Play, Pause } from 'lucide-react'
 
 // PERF constants
-
-// Mobile-lite detection & worker
-const mobileLiteRef = useRef(false)
-const vizWorkerRef = useRef(null)
 const PERF = { LOOK_AHEAD: 0.12, MAX_EVENTS_PER_TICK: 10, MAX_SYNTH_VOICES: 8, IMG_MAX_SIZE: 180, SAMPLE_STRIDE: 20, MAX_PARTICLES: 700 }
 
 // Helpers
@@ -225,6 +221,9 @@ export default function ColorSynth(){
   // Pool diatónico extendido a varias octavas para “lock” absoluto
   const diatonicPool = expandPool(scalePool, 4, 3)
 
+  const mobileLiteRef = useRef(false)
+  const vizWorkerRef = useRef(null)
+
   // mixer
   const [mix, setMix] = useState({ drone:-12, pad:-8 })
   const busGainsRef = useRef({ drone: null, pad: null })
@@ -335,7 +334,7 @@ export default function ColorSynth(){
     const smallScreen = (window.innerWidth || 0) < 820
     mobileLiteRef.current = !!(isMobileUA || smallScreen)
   },[])
-useEffect(()=>{
+  useEffect(()=>{
     try{ workerRef.current = new Worker(new URL('../workers/analyze.worker.js', import.meta.url), { type:'module' }) }catch{}
     return ()=>{ workerRef.current?.terminate(); workerRef.current=null }
   },[])


### PR DESCRIPTION
## Summary
- normalize React imports to named hooks
- move mobile and viz worker refs inside `ColorSynth`
- replace React.* hook usages with direct imports

## Testing
- `npm run build`
- `rg 'React\.use(Ref|State|Effect|Memo)\(' -n`
- `rg '^use(Ref|State|Effect|Memo)\(' -n`


------
https://chatgpt.com/codex/tasks/task_e_68bf363d50848325a8bb434984e9b5ed